### PR TITLE
Fixed bad typing in event delegate

### DIFF
--- a/Source/LSL/Public/LSLTypes.h
+++ b/Source/LSL/Public/LSLTypes.h
@@ -6,7 +6,7 @@
 // Delegate types
 //---------------------------------------------------
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FLSLStreamUpdatedFloatDelegate, TArray<float>, FloatArray, float, DeltaSeconds);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FLSLStreamUpdatedFloatDelegate, const TArray<float>&, FloatArray, float, DeltaSeconds);
 
 UENUM(BlueprintType)
 enum class EChannelFormat : uint8


### PR DESCRIPTION
Hi Chad,

This fix is relative to #3. I had never tested Inlets before, and found on issue while making an example BP for the issue (for some reason, arrays needs to be passed by reference in event delegates).

Bertrand