### PR TITLE
fix: string formatting for float number

### DIFF
--- a/Source/LSL/Private/LSLOutletComponent.cpp
+++ b/Source/LSL/Private/LSLOutletComponent.cpp
@@ -22,7 +22,7 @@ void ULSLOutletComponent::BeginPlay()
 {
     Super::BeginPlay();
     //lsl_streaminfo lsl_myinfo = lsl_create_streaminfo(TCHAR_TO_ANSI(*StreamName), TCHAR_TO_ANSI(*StreamType), ChannelCount, SamplingRate, (lsl_channel_format_t)ChannelFormat, TCHAR_TO_ANSI(*StreamID));
-    UE_LOG(LogLSL, Log, TEXT("Attempting to create stream outlet with name %s, type %s, sampling rate %d."), *StreamName, *StreamType, SamplingRate);
+    UE_LOG(LogLSL, Log, TEXT("Attempting to create stream outlet with name %s, type %s, sampling rate %f."), *StreamName, *StreamType, SamplingRate);
     lsl::stream_info data_info(
 		TCHAR_TO_ANSI(*StreamName),
 		TCHAR_TO_ANSI(*StreamType),


### PR DESCRIPTION
I apologize for the very small change. But I am setting up my Unreal project with submodules (one of which is this plugin) and this one issue crashes my build. I would be easier for me to have it fixed, so people that clone my repo can hit the ground running instead of instructing them on how to make this change all the times.

Thanks! 

+Enea